### PR TITLE
Feature/80 save last step does not save xml and Feature/88 Scenario summary not created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Next version (not released)
 
-Breaking Changes:
+###Breaking Changes:
 
 * Not using the WebDriver Control Flow anymore, so you should set `SELENIUM_PROMISE_MANAGER` to `0` in your protractor config file.
 
-Other Changes:
+### Bug Fixes
+* When saveLastStep is activated then both the screenshot and the step.xml are correctly created.
+
+###Other Changes:
 
 * Update Libraries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## Next version (not released)
 
-###Breaking Changes:
+### Breaking Changes:
 
 * Not using the WebDriver Control Flow anymore, so you should set `SELENIUM_PROMISE_MANAGER` to `0` in your protractor config file.
 
 ### Bug Fixes
 * When saveLastStep is activated then both the screenshot and the step.xml are correctly created.
 
-###Other Changes:
+### Other Changes:
 
 * Update Libraries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Not using the WebDriver Control Flow anymore, so you should set `SELENIUM_PROMISE_MANAGER` to `0` in your protractor config file.
 
 ### Bug Fixes
-* When saveLastStep is activated then both the screenshot and the step.xml are correctly created.
+* When saveLastStep is activated then both the screenshot and the step.xml are correctly created. ([#80](https://github.com/scenarioo/scenarioo-js/issues/80))
 
 ### Other Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 * When saveLastStep is activated then both the screenshot and the step.xml are correctly created. ([#80](https://github.com/scenarioo/scenarioo-js/issues/80))
+* When using the fluent DSL, description is now optional for use cases. ([#88](https://github.com/scenarioo/scenarioo-js/issues/88))
 
 ### Other Changes:
 

--- a/example/test/exampleFluentDsl.spec.js
+++ b/example/test/exampleFluentDsl.spec.js
@@ -55,6 +55,27 @@ useCase('Example Use Case with Fluent DSL')
 
       });
 
+    scenario('Example Scenario with Fluent DSL without description')
+      .labels(['happy', 'example-label'])
+      .it(function () {
+
+        browser.get('/index.html');
+
+        // use the step method to document interaction steps inside the scenario (with screenshot, etc.)
+        step('browse to start page');
+        // you could also hook such saveStep method calls into your page objects or even the e2e test toolkit
+        // (e.g. by overwriting protractor functions, like click on element)
+        // to automatically document a step on each important interaction and not clutter your tests with such calls
+        // (actually that is what we recommend for real projects and can be done easily).
+
+        // A step could also have additional propoerties, like e.g. labels (or screen annotations, as you can see in other examples
+        // (see pure jasmine example for other possibilities in steps)
+        step('a step with labels', {labels: ['step-label-example']});
+
+        // more steps of this scenario would of course come here ...
+
+      });
+
     scenario('Example Failing Scenario with several expectation failures')
       .description('This scenario should demonstrate that also for each failed expectation a screenshot is taken')
       .it(function exampleScenarioWithMultipleExpectationsFailingAndNoLabels() {

--- a/lib/dsl/fluentDsl.js
+++ b/lib/dsl/fluentDsl.js
@@ -105,7 +105,8 @@ function useCase(name) {
 }
 
 function scenario(name) {
-  var _description2, _labels2, pendingMessage;
+  var _description2 = '';
+  var _labels2, pendingMessage;
 
   return {
     description: function description(d) {

--- a/lib/scenarioo-js.js
+++ b/lib/scenarioo-js.js
@@ -168,7 +168,7 @@ var scenarioo = {
           }
 
           // Report step with status and failure label
-          scenarioo.saveStep('scenario ' + status, {
+          return scenarioo.saveStep('scenario ' + status, {
             status: status,
             labels: labels
           });

--- a/src/dsl/fluentDsl.js
+++ b/src/dsl/fluentDsl.js
@@ -97,7 +97,8 @@ export function useCase(name) {
 
 export function scenario(name) {
 
-  var description, labels, pendingMessage;
+  var description = '';
+  var labels, pendingMessage;
 
   return {
     description: function (d) {


### PR DESCRIPTION
Fixes #80
Fixes #88

When saveLastStep is activated in the configuration then a step (with screenshot and step.xml) would be created after a test has completed. Currently, however only the screenshot was created and the step.xml was missing.

The reason for this was that the test runner closed the browser during the execution of docuWriter.writeStepXml(). And this happened because saveLastStep returned nothing instead of the promise of saveStep and thus the test runner did not wait for saveLastStep to complete and terminated the browser too soon.

I tested this with the supplied example https://github.com/sbrugnoni/scenarioo-js-minimal-example using scenario-js from this branch and the step.xml was correctly created and displayed in the Scenarioo web client.
